### PR TITLE
Add redirects for old URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,7 +56,7 @@ feed:
 
 # Don't copy these files to the generated site
 exclude: [CNAME, Gemfile, Gemfile.lock, LICENSE.md, Rakefile, README.md, vendor, img/src]
-# Include _headers, else they don't take effect
-include: [_headers]
+# Include _headers and _redirects, else they don't take effect
+include: [_headers, _redirects]
 # Don't attempt to process these - ie leave as-is
 keep_files: [assets, img]

--- a/_redirects
+++ b/_redirects
@@ -1,13 +1,16 @@
 # Netlify redirects - see https://www.netlify.com/docs/redirects/
 #
-# Old                                               New       Code if not 301
+# Old                                                         New       Code if not 301
 
 # Gone pages
-/blog/xmlrpc.php                                    /         410
-/calendar/*                                         /         410
-/downloads/Clarkson-Aug06.pdf                       /         410
-/post-name                                          /         410
-/rss/madamandeve.rss                                /         410
+/$1                                                           /         410
+/archives/2006/01/19/wordpress-20-is-a-mod_rewrite-hijacker   /         410
+/blog/xmlrpc.php                                              /         410
+/calendar/*                                                   /         410
+/christmas-gift-ideas-2010                                    /         410
+/downloads/Clarkson-Aug06.pdf                                 /         410
+/post-name                                                    /         410
+/rss/madamandeve.rss                                          /         410
 
 # Redirects
 /archives/:year/:month/:date/:slug                  /:slug

--- a/_redirects
+++ b/_redirects
@@ -3,11 +3,11 @@
 # Old                                               New       Code if not 301
 
 # Gone pages
-/blog/xmlrpc.php                                    /410      410
-/calendar/*                                         /410      410
-/downloads/Clarkson-Aug06.pdf                       /410      410
-/post-name                                          /410      410
-/rss/madamandeve.rss                                /410      410
+/blog/xmlrpc.php                                    /         410
+/calendar/*                                         /         410
+/downloads/Clarkson-Aug06.pdf                       /         410
+/post-name                                          /         410
+/rss/madamandeve.rss                                /         410
 
 # Redirects
 /archives/:year/:month/:date/:slug                  /:slug

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,27 @@
+# Netlify redirects - see https://www.netlify.com/docs/redirects/
+#
+# Old                                               New       Code if not 301
+
+# Gone pages
+/blog/xmlrpc.php                                    /410      410
+/calendar/*                                         /410      410
+/downloads/Clarkson-Aug06.pdf                       /410      410
+/post-name                                          /410      410
+/rss/madamandeve.rss                                /410      410
+
+# Redirects
+/archives/:year/:month/:date/:slug                  /:slug
+/blog                                               /
+/blog/:slug                                         /:slug
+/gallery                                            https://colinseymour.smugmug.com/
+
+# Renames
+/barneys-brew                                       /enpct3jt0o
+/celebrating-everything-british                     /edbmqxpt2u
+/nelson-saison                                      /dm6gbzjt8x
+/powerpoint-40-on-vhs                               /fc9hshpt7j
+/toadstool                                          /gv438sptw9
+
+# Moved sites
+/first-road-race-podium-finish                      https://gonefora.run/first-road-race-podium-finish
+/techie/solaris-10-stuff/:slug                      https://lildude.co.uk/:slug


### PR DESCRIPTION
Life goes on and so the structure of this site has evolved over time leaving things stranded. Google kindly reminded me that I have several links that are now 404ing - they're been doing it for a while so no idea why the sudden interest now.

Anyway, this PR fixes this by introducing redirects supported by Netlify - https://www.netlify.com/docs/redirects/